### PR TITLE
Fixed empty feedback being stored as feedback

### DIFF
--- a/src/main/java/seedu/superta/logic/parser/FeedbackCommandParser.java
+++ b/src/main/java/seedu/superta/logic/parser/FeedbackCommandParser.java
@@ -6,6 +6,8 @@ import static seedu.superta.logic.parser.CliSyntax.PREFIX_FEEDBACK;
 import static seedu.superta.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static seedu.superta.logic.parser.ParserUtil.arePrefixesPresent;
 
+import java.util.Optional;
+
 import seedu.superta.logic.commands.FeedbackCommand;
 import seedu.superta.logic.parser.exceptions.ParseException;
 import seedu.superta.model.student.Feedback;
@@ -34,14 +36,17 @@ public class FeedbackCommandParser implements Parser<FeedbackCommand> {
                 FeedbackCommand.MESSAGE_USAGE));
         }
 
-        StudentId stId = ParserUtil.parseStudentId(
-            argMap.getValue(PREFIX_STUDENT_ID).get()
-        );
+        Optional<String> studentId = argMap.getValue(PREFIX_STUDENT_ID);
+        Optional<String> feedback = argMap.getValue(PREFIX_FEEDBACK);
 
-        Feedback feedback = ParserUtil.parseFeedback(
-                argMap.getValue(PREFIX_FEEDBACK).get()
-        );
+        if (studentId.get().isEmpty() || feedback.get().isEmpty()) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, FeedbackCommand.MESSAGE_USAGE));
+        }
 
-        return new FeedbackCommand(stId, feedback);
+        StudentId stId = ParserUtil.parseStudentId(studentId.get());
+        Feedback fdBk = ParserUtil.parseFeedback(feedback.get());
+
+        return new FeedbackCommand(stId, fdBk);
     }
 }

--- a/src/test/java/seedu/superta/logic/parser/FeedbackCommandParserTest.java
+++ b/src/test/java/seedu/superta/logic/parser/FeedbackCommandParserTest.java
@@ -30,11 +30,19 @@ public class FeedbackCommandParserTest {
     @Test
     public void parse_missingCompulsoryField_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FeedbackCommand.MESSAGE_USAGE);
-        // student id missing
+
+        // student id + prefix missing
         assertParseFailure(parser, " f/" + nonEmptyFeedback, expectedMessage);
-        // feedback missing
+        // feedback + prefix missing
         assertParseFailure(parser, " id/" + VALID_STUDENT_ID_AMY, expectedMessage);
         // all prefixes missing
         assertParseFailure(parser, "", expectedMessage);
+
+        // student id prefix present, actual student id missing
+        assertParseFailure(parser, " id/ f/" + nonEmptyFeedback, expectedMessage);
+        // feedback prefix present, actual feedback missing
+        assertParseFailure(parser, " id/" + VALID_STUDENT_ID_AMY + " f/", expectedMessage);
+        // student id and feedback prefix present, actual student id and feedback missing
+        assertParseFailure(parser, " id/ f/", expectedMessage);
     }
 }


### PR DESCRIPTION
1. FeedbackCommandParser now detects empty feedback/student id before creating FeedbackCommand
2. Edited tests to cover empty feedback/student id test cases

