### PR TITLE
Fix attendance (v1.3.3)

### DIFF
--- a/src/main/java/seedu/superta/MainApp.java
+++ b/src/main/java/seedu/superta/MainApp.java
@@ -40,7 +40,7 @@ import seedu.superta.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 3, 2, true);
+    public static final Version VERSION = new Version(1, 3, 3, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/superta/model/SuperTaClient.java
+++ b/src/main/java/seedu/superta/model/SuperTaClient.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
-
 import seedu.superta.model.assignment.Assignment;
 import seedu.superta.model.assignment.Grade;
 import seedu.superta.model.assignment.exceptions.AssignmentNotFoundException;
@@ -19,6 +18,7 @@ import seedu.superta.model.assignment.exceptions.GradeException;
 import seedu.superta.model.attendance.Attendance;
 import seedu.superta.model.attendance.Presence;
 import seedu.superta.model.attendance.Session;
+import seedu.superta.model.attendance.exceptions.DuplicateAttendanceException;
 import seedu.superta.model.attendance.exceptions.DuplicateSessionException;
 import seedu.superta.model.attendance.exceptions.SessionNotFoundException;
 import seedu.superta.model.student.Feedback;
@@ -240,7 +240,13 @@ public class SuperTaClient implements ReadOnlySuperTaClient {
         }
 
         Presence present = Presence.PRESENT;
-        stIdSet.stream().map(stdId -> new Attendance(stdId, present)).forEach(att -> sess.addToSession(att));
+        List<Attendance> attendanceList = stIdSet.stream().map(stdId -> new Attendance(stdId, present))
+                .collect(Collectors.toList());
+        boolean hasDuplicateAttendance = attendanceList.stream().anyMatch(attendance -> sess.contains(attendance));
+        if (hasDuplicateAttendance) {
+            throw new DuplicateAttendanceException();
+        }
+        attendanceList.stream().forEach(sess::addToSession);
     }
 
     /**

--- a/src/main/java/seedu/superta/model/tutorialgroup/TutorialGroupMaster.java
+++ b/src/main/java/seedu/superta/model/tutorialgroup/TutorialGroupMaster.java
@@ -130,7 +130,6 @@ public class TutorialGroupMaster {
         ObservableList<TutorialGroup> list = FXCollections.observableArrayList();
         list.addAll(tutorialGroups.values());
         tutorialGroups.addListener((MapChangeListener<? super String, ? super TutorialGroup>) change -> {
-            System.out.println(change.getKey());
             if (change.wasAdded()) {
                 list.add(change.getValueAdded());
             }

--- a/src/test/java/seedu/superta/logic/commands/DeleteTutorialGroupCommandTest.java
+++ b/src/test/java/seedu/superta/logic/commands/DeleteTutorialGroupCommandTest.java
@@ -56,7 +56,6 @@ public class DeleteTutorialGroupCommandTest {
 
         //same String object -> returns true
         DeleteTutorialGroupCommand firstCommandCopy = new DeleteTutorialGroupCommand(TG_ID_TO_DELETE);
-        System.out.println(firstCommand.equals(firstCommandCopy));
         assertTrue(firstCommand.equals(firstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/superta/logic/parser/UpdateTutorialGroupParserTest.java
+++ b/src/test/java/seedu/superta/logic/parser/UpdateTutorialGroupParserTest.java
@@ -34,7 +34,6 @@ public class UpdateTutorialGroupParserTest {
     public void parse_allFieldsSpecified_success() {
         String userInput = " " + PREFIX_TUTORIAL_GROUP_ID + typicalId + " "
             + PREFIX_TUTORIAL_GROUP_NAME + typicalName;
-        System.out.println(userInput);
         UpdateTutorialGroupCommand.UpdateTutorialGroupDescriptor descriptor = new UpdateTutorialGroupCommand
             .UpdateTutorialGroupDescriptor();
         descriptor.setName(typicalName);


### PR DESCRIPTION
Fix mark-attendance to work as expected with the new restriction of duplicate attendance not allowed. Previously it would add all attendances until it hit a student whose attendance is already marked, which then would fail. However, the added attendances will be reflected, which is not the intended behaviour. We want each command to be a transaction.